### PR TITLE
Initialize RunSafe CLI scaffolding

### DIFF
--- a/bin/runsafe
+++ b/bin/runsafe
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../src/cli.ts';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "runsafe",
+  "version": "0.1.0",
+  "type": "module",
+  "bin": {
+    "runsafe": "./bin/runsafe"
+  },
+  "dependencies": {
+    "commander": "^11.0.0",
+    "chalk": "^5.3.0"
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,76 @@
+// Main CLI definition using commander
+
+import { Command } from 'commander';
+import { loadConfig } from './utils/config.js';
+import { logInfo, logError } from './utils/logger.js';
+
+function showBanner() {
+  const banner = `
+ _____                 _____         __
+|  __ \               / ____|       / _|
+| |__) |__ _ _ __ ___| (___   ___  | |_ ___  _ __
+|  _  // _` | '__/ _ \\___ \ / _ \ |  _/ _ \| '__|
+| | \ \ (_| | | |  __/____) |  __/ | || (_) | |
+|_|  \_\__,_|_|  \___|_____/ \___| |_| \___/|_|
+`;
+  logInfo(banner);
+}
+
+export async function run(argv: string[]): Promise<void> {
+  const program = new Command();
+
+  program
+    .name('runsafe')
+    .description('RunSafe CLI');
+
+  program
+    .command('apply')
+    .description('Apply pending operations')
+    .action(async () => {
+      logInfo('RunSafe: apply invoked');
+    });
+
+  program
+    .command('validate')
+    .description('Validate configuration')
+    .action(async () => {
+      logInfo('RunSafe: validate invoked');
+    });
+
+  program
+    .command('doctor')
+    .description('Run diagnostics')
+    .action(async () => {
+      logInfo('RunSafe: doctor invoked');
+    });
+
+  program
+    .command('scout')
+    .description('Scout for updates')
+    .action(async () => {
+      logInfo('RunSafe: scout invoked');
+    });
+
+  program
+    .command('chains')
+    .description('Manage chains')
+    .action(async () => {
+      logInfo('RunSafe: chains invoked');
+    });
+
+  program
+    .action(() => {
+      showBanner();
+    });
+
+  try {
+    await loadConfig();
+    await program.parseAsync(argv);
+  } catch (err: any) {
+    logError(err.message);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run(process.argv);
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,28 @@
+// Configuration loader for RunSafe
+
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+
+export interface RunSafeConfig {
+  [key: string]: unknown;
+}
+
+async function readJSON(filePath: string): Promise<RunSafeConfig> {
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return {};
+  }
+}
+
+export async function loadConfig(): Promise<RunSafeConfig> {
+  const cwdFile = path.join(process.cwd(), '.runsaferc.json');
+  const homeFile = path.join(os.homedir(), '.runsaferc.json');
+
+  const homeConfig = await readJSON(homeFile);
+  const cwdConfig = await readJSON(cwdFile);
+
+  return { ...homeConfig, ...cwdConfig };
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,15 @@
+// Logger utilities using chalk for consistent output
+
+import chalk from 'chalk';
+
+export function logInfo(message: string): void {
+  console.log(chalk.cyan(message));
+}
+
+export function logSuccess(message: string): void {
+  console.log(chalk.green(message));
+}
+
+export function logError(message: string): void {
+  console.error(chalk.red(message));
+}


### PR DESCRIPTION
## Summary
- add CLI entrypoint and command structure
- add logger and config utilities
- scaffold package.json with ESM and dependencies
- provide bin script for running the CLI

## Testing
- `pnpm install` *(fails: forbidden to access registry)*

------
https://chatgpt.com/codex/tasks/task_e_6863d87e904c832cbc68da2ab759094a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a command-line interface (CLI) with commands: apply, validate, doctor, scout, and chains.
  * Added configuration loading from user and project directories with automatic merging.
  * Implemented color-coded logging for informational, success, and error messages.
  * Provided an executable script for launching the CLI tool.

* **Chores**
  * Added a project manifest with metadata and dependency management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->