### PR TITLE
Implement runsafe apply command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@
 import { Command } from 'commander';
 import { loadConfig } from './utils/config.js';
 import { logInfo, logError } from './utils/logger.js';
+import { applyEpic } from './commands/apply.js';
 
 function showBanner() {
   const banner = `
@@ -24,10 +25,13 @@ export async function run(argv: string[]): Promise<void> {
     .description('RunSafe CLI');
 
   program
-    .command('apply')
-    .description('Apply pending operations')
-    .action(async () => {
-      logInfo('RunSafe: apply invoked');
+    .command('apply <epic>')
+    .description('Apply file edits from epic markdown')
+    .option('--dry-run', 'show intended changes only, do not apply')
+    .option('--diff', 'display unified diffs before applying')
+    .option('--atomic', 'apply all changes as a single transaction; if any fail, rollback all')
+    .action(async (epic: string, opts: any) => {
+      await applyEpic(epic, opts);
     });
 
   program

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -1,0 +1,120 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import chalk from 'chalk';
+import { logInfo, logError, logSuccess } from '../utils/logger.js';
+import { parseEpic, FileEdit } from '../utils/parseEpic.js';
+
+interface ApplyOptions {
+  dryRun?: boolean;
+  diff?: boolean;
+  atomic?: boolean;
+}
+
+function isBinary(buf: Buffer): boolean {
+  for (let i = 0; i < buf.length; i++) {
+    const char = buf[i];
+    if (char === 0) return true;
+  }
+  return false;
+}
+
+function applyEdit(content: string, edit: FileEdit): string {
+  const target = edit.target.join('\n');
+  const replacement = edit.replacement?.join('\n') ?? '';
+  switch (edit.type) {
+    case 'replace':
+      if (!content.includes(target)) throw new Error(`target not found for replace in ${edit.filePath}`);
+      return content.replace(target, replacement);
+    case 'insert-before':
+      if (!content.includes(target)) throw new Error(`target not found for insert-before in ${edit.filePath}`);
+      return content.replace(target, `${replacement}\n${target}`);
+    case 'insert-after':
+      if (!content.includes(target)) throw new Error(`target not found for insert-after in ${edit.filePath}`);
+      return content.replace(target, `${target}\n${replacement}`);
+    case 'delete':
+      if (!content.includes(target)) throw new Error(`target not found for delete in ${edit.filePath}`);
+      return content.replace(target, '');
+    default:
+      return content;
+  }
+}
+
+function diffLines(oldStr: string, newStr: string): string {
+  const oldLines = oldStr.split(/\r?\n/);
+  const newLines = newStr.split(/\r?\n/);
+  let out = '';
+  oldLines.forEach((line, i) => {
+    if (newLines[i] === undefined) {
+      out += chalk.red(`- ${line}\n`);
+    } else if (newLines[i] !== line) {
+      out += chalk.red(`- ${line}\n`);
+      out += chalk.green(`+ ${newLines[i]}\n`);
+    } else {
+      out += `  ${line}\n`;
+    }
+  });
+  for (let j = oldLines.length; j < newLines.length; j++) {
+    out += chalk.green(`+ ${newLines[j]}\n`);
+  }
+  return out;
+}
+
+export async function applyEpic(file: string, options: ApplyOptions): Promise<void> {
+  const workspace = process.cwd();
+  const epicPath = path.resolve(workspace, file);
+  const md = await fs.readFile(epicPath, 'utf8');
+  const epic = parseEpic(md);
+
+  logInfo(`Summary:\n${epic.summary}`);
+
+  const fileContents = new Map<string, { original: string; updated: string }>();
+
+  for (const edit of epic.edits) {
+    const absPath = path.resolve(workspace, edit.filePath);
+    if (!absPath.startsWith(workspace)) {
+      throw new Error(`Path ${edit.filePath} is outside workspace`);
+    }
+    if (absPath.includes(`${path.sep}node_modules${path.sep}`) || absPath.includes(`${path.sep}.git${path.sep}`)) {
+      throw new Error(`Modification of protected path ${edit.filePath} not allowed`);
+    }
+    const buf = await fs.readFile(absPath);
+    if (isBinary(buf)) throw new Error(`Binary file ${edit.filePath} not allowed`);
+    const text = buf.toString('utf8');
+    const existing = fileContents.get(absPath) || { original: text, updated: text };
+    existing.updated = applyEdit(existing.updated, edit);
+    fileContents.set(absPath, existing);
+
+    if (options.dryRun) {
+      logInfo(`${edit.filePath} -> ${edit.type}`);
+      const preview = diffLines(text, existing.updated);
+      logInfo(preview);
+    }
+  }
+
+  if (options.dryRun) {
+    return;
+  }
+
+  const backups: Map<string, string> = new Map();
+  try {
+    for (const [absPath, data] of fileContents.entries()) {
+      if (options.diff) {
+        const d = diffLines(data.original, data.updated);
+        logInfo(`Diff for ${absPath}:\n${d}`);
+      }
+      if (options.atomic) {
+        backups.set(absPath, data.original);
+      }
+      await fs.writeFile(absPath, data.updated, 'utf8');
+    }
+    logSuccess('All changes applied');
+  } catch (err) {
+    logError((err as Error).message);
+    if (options.atomic) {
+      for (const [absPath, orig] of backups.entries()) {
+        await fs.writeFile(absPath, orig, 'utf8');
+      }
+      logError('Rolled back changes due to failure');
+    }
+  }
+}

--- a/src/utils/parseEpic.ts
+++ b/src/utils/parseEpic.ts
@@ -1,0 +1,60 @@
+// Helper to parse epic markdown files
+
+export interface FileEdit {
+  filePath: string;
+  type: 'replace' | 'insert-before' | 'insert-after' | 'delete';
+  target: string[];
+  replacement?: string[];
+}
+
+export interface Epic {
+  summary: string;
+  edits: FileEdit[];
+}
+
+function splitSections(md: string): { summary: string; editsSection: string } {
+  const summaryMatch = md.match(/Summary\n([\s\S]*?)(?:\n#+\s*|\nFile Edits|$)/i);
+  const summary = summaryMatch ? summaryMatch[1].trim() : '';
+
+  const fileEditsIndex = md.indexOf('File Edits');
+  const editsSection = fileEditsIndex !== -1 ? md.slice(fileEditsIndex + 'File Edits'.length).trim() : '';
+
+  return { summary, editsSection };
+}
+
+export function parseEpic(md: string): Epic {
+  const { summary, editsSection } = splitSections(md);
+  const lines = editsSection.split(/\r?\n/);
+  const edits: FileEdit[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    let filePath = lines[i]?.trim();
+    if (!filePath) { i++; continue; }
+    // ignore stray labels
+    if (['yaml', 'Copy', 'Edit'].includes(filePath)) { i++; continue; }
+    i++;
+    const type = (lines[i] || '').trim() as FileEdit['type'];
+    if (!type) { break; }
+    i++;
+    const target: string[] = [];
+    while (i < lines.length && lines[i].trim() !== 'with' && lines[i].trim() !== '') {
+      target.push(lines[i]);
+      i++;
+    }
+    let replacement: string[] | undefined;
+    if (type !== 'delete') {
+      // skip blank lines until 'with'
+      while (i < lines.length && lines[i].trim() !== 'with') { i++; }
+      if (lines[i] && lines[i].trim() === 'with') i++;
+      replacement = [];
+      while (i < lines.length && lines[i].trim() !== '') {
+        replacement.push(lines[i]);
+        i++;
+      }
+    }
+    // skip any remaining blank lines
+    while (i < lines.length && lines[i].trim() === '') i++;
+    edits.push({ filePath, type, target, replacement });
+  }
+  return { summary, edits };
+}


### PR DESCRIPTION
## Summary
- add utility to parse epic markdown files
- implement `apply` command logic for applying file edits
- wire new command into CLI with options

## Testing
- `npm test` *(fails: Missing script)*
- `npm ls` *(fails: missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_6863dc163618832c9b3dcb6ac8c4b4de

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a command-line option to apply file edits from an epic markdown file, supporting dry-run, diff preview, and atomic application modes.
  * Added detailed validation and preview of file changes before applying them.
  * Enhanced CLI with new flags for safer and more transparent file editing workflows.

* **Bug Fixes**
  * Prevented edits to binary files and protected directories to improve safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->