### PR TITLE
Add centralized success logging and dry-run notice

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -4,7 +4,8 @@ import chalk from 'chalk';
 import {
   logInfo,
   logError,
-  logSuccess,
+  logSuccessFinal,
+  logDryRunNotice,
   logWarn,
   logCooldownWarning,
 } from '../utils/logger.js';
@@ -108,6 +109,7 @@ export async function applyEpic(file: string, options: ApplyOptions): Promise<vo
   }
 
   if (options.dryRun) {
+    logDryRunNotice();
     return;
   }
 
@@ -126,7 +128,7 @@ export async function applyEpic(file: string, options: ApplyOptions): Promise<vo
       );
       await fs.writeFile(absPath, data.updated, 'utf8');
     }
-    logSuccess('🌱 Your changes were safely planted.');
+    logSuccessFinal('Your changes were safely planted.');
     await writePasteLog({
       timestamp: new Date().toISOString(),
       file,

--- a/src/commands/chains.ts
+++ b/src/commands/chains.ts
@@ -2,7 +2,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { load as loadYaml } from 'js-yaml';
-import { logBanner, logError, logWarn } from '../utils/logger.js';
+import { logBanner, logError, logWarn, logSuccessFinal } from '../utils/logger.js';
 import { applyEpic } from './apply.js';
 
 interface ChainItem {
@@ -73,4 +73,6 @@ export async function runChains(): Promise<void> {
       return;
     }
   }
+
+  logSuccessFinal('Chain completed successfully.');
 }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
-import { logInfo, logSuccess, logError, logWarn } from '../utils/logger.js';
+import { logInfo, logSuccess, logError, logWarn, logSuccessFinal } from '../utils/logger.js';
 import { resetCooldown, recordFailure } from '../utils/telemetry.js';
 
 async function checkNodeVersion(): Promise<boolean> {
@@ -103,7 +103,7 @@ export async function runDoctor(): Promise<void> {
     logError('🚨 Something looks off. Use runsafe doctor to investigate.');
     await recordFailure();
   } else {
-    logSuccess('✅ All systems go!');
+    logSuccessFinal('All systems go! 🚀');
     await resetCooldown();
   }
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { parseEpic, FileEdit } from '../utils/parseEpic.js';
-import { logError, logSuccess } from '../utils/logger.js';
+import { logError, logSuccessFinal } from '../utils/logger.js';
 import { recordFailure } from '../utils/telemetry.js';
 
 interface ValidateOptions {
@@ -67,7 +67,7 @@ export async function validateEpic(file: string, opts: ValidateOptions): Promise
     }
   }
 
-  logSuccess('✅ Epic is valid and safe to apply.');
+  logSuccessFinal("Validation passed. You're good to go!");
 
   if (opts.council) {
     const council =

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -44,3 +44,13 @@ export function logCooldownWarning(): void {
     )
   );
 }
+
+export function logSuccessFinal(msg: string): void {
+  if (quiet) return;
+  console.log(chalk.green(`🌱 ${msg}`));
+}
+
+export function logDryRunNotice(): void {
+  if (quiet) return;
+  console.log(chalk.yellow('🚧 Dry-run mode enabled. No changes were written.'));
+}


### PR DESCRIPTION
## Summary
- add `logSuccessFinal` and `logDryRunNotice` helpers
- use helpers in `apply`, `validate`, `doctor`, and `chains`
- give success output with 🌱 or 🚀 icons

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864a91401dc832c864032a692e64700