### PR TITLE
Add Jest test scaffold

### DIFF
--- a/__tests__/sample.test.ts
+++ b/__tests__/sample.test.ts
@@ -1,0 +1,3 @@
+test('RunSafe test system works', () => {
+  expect(1 + 1).toBe(2);
+});

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,13 @@
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+  transform: {},
+  moduleNameMapper: {},
+  testMatch: ['**/__tests__/**/*.test.ts'],
+};

--- a/package.json
+++ b/package.json
@@ -9,5 +9,13 @@
     "commander": "^11.0.0",
     "chalk": "^5.3.0",
     "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "jest": "^29.6.0",
+    "ts-jest": "^29.1.0",
+    "@types/jest": "^29.5.0"
+  },
+  "scripts": {
+    "test": "jest"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest + ts-jest config for ESM TypeScript
- include a simple sample test
- add test script and dev dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864aa81cbfc832cb119e397a8ac8f32