### PR TITLE
Add multi-agent council test suite

### DIFF
--- a/__tests__/multiAgentReview.test.ts
+++ b/__tests__/multiAgentReview.test.ts
@@ -1,0 +1,88 @@
+import { jest } from '@jest/globals';
+import { multiAgentReview } from '../src/ai/multiAgentReview.js';
+import * as agentModule from '../src/ai/agentReview.js';
+
+describe('multiAgentReview', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('returns APPROVED when all agents vote positive', async () => {
+    jest
+      .spyOn(agentModule, 'callAgentReview')
+      .mockResolvedValue({ vote: 'APPROVED', note: 'great' });
+
+    const result = await multiAgentReview('valid epic');
+    expect(result.decision).toBe('APPROVED');
+    expect(result.agentVotes).toEqual([
+      'APPROVED',
+      'APPROVED',
+      'APPROVED',
+      'APPROVED',
+    ]);
+    expect(result.notes).toEqual(['great', 'great', 'great', 'great']);
+  });
+
+  test('returns REJECTED when majority vote negative', async () => {
+    const mock = jest.spyOn(agentModule, 'callAgentReview');
+    mock
+      .mockResolvedValueOnce({ vote: 'REJECTED', note: 'bad' })
+      .mockResolvedValueOnce({ vote: 'REJECTED', note: 'bad' })
+      .mockResolvedValueOnce({ vote: 'REJECTED', note: 'bad' })
+      .mockResolvedValueOnce({ vote: 'APPROVED', note: 'ok' });
+
+    const result = await multiAgentReview('valid epic');
+    expect(result.decision).toBe('REJECTED');
+  });
+
+  test('returns REJECTED when votes are split evenly', async () => {
+    const mock = jest.spyOn(agentModule, 'callAgentReview');
+    mock
+      .mockResolvedValueOnce({ vote: 'APPROVED', note: 'ok' })
+      .mockResolvedValueOnce({ vote: 'REJECTED', note: 'bad' })
+      .mockResolvedValueOnce({ vote: 'APPROVED', note: 'ok' })
+      .mockResolvedValueOnce({ vote: 'REJECTED', note: 'bad' });
+
+    const result = await multiAgentReview('valid epic');
+    expect(result.decision).toBe('REJECTED');
+  });
+
+  test('captures notes from all agents', async () => {
+    const mock = jest.spyOn(agentModule, 'callAgentReview');
+    mock
+      .mockResolvedValueOnce({ vote: 'APPROVED', note: 'a' })
+      .mockResolvedValueOnce({ vote: 'APPROVED', note: 'b' })
+      .mockResolvedValueOnce({ vote: 'APPROVED', note: 'c' })
+      .mockResolvedValueOnce({ vote: 'APPROVED', note: 'd' });
+
+    const result = await multiAgentReview('valid epic');
+    expect(result.notes).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  test('deterministic mode returns consistent results', async () => {
+    jest
+      .spyOn(agentModule, 'callAgentReview')
+      .mockResolvedValue({ vote: 'APPROVED', note: 'yes' });
+
+    const first = await multiAgentReview('epic', { deterministic: true });
+    const second = await multiAgentReview('epic', { deterministic: true });
+    expect(first).toEqual(second);
+  });
+
+  test('handles malformed epic input gracefully', async () => {
+    const result = await multiAgentReview('');
+    expect(result.decision).toBe('REJECTED');
+    expect(result.agentVotes).toEqual([]);
+    expect(result.notes[0]).toMatch(/malformed/i);
+  });
+
+  test('handles all agents abstaining', async () => {
+    jest
+      .spyOn(agentModule, 'callAgentReview')
+      .mockResolvedValue({ vote: undefined, note: '' });
+
+    const result = await multiAgentReview('valid epic');
+    expect(result.decision).toBe('REJECTED');
+    expect(result.agentVotes).toEqual([undefined, undefined, undefined, undefined]);
+  });
+});

--- a/src/ai/agentReview.ts
+++ b/src/ai/agentReview.ts
@@ -1,0 +1,12 @@
+export interface AgentVote {
+  vote?: 'APPROVED' | 'REJECTED';
+  note?: string;
+}
+
+export async function callAgentReview(
+  name: string,
+  epicContent: string
+): Promise<AgentVote> {
+  // Placeholder implementation that will be mocked in tests
+  return { vote: 'APPROVED', note: '' };
+}

--- a/src/ai/multiAgentReview.ts
+++ b/src/ai/multiAgentReview.ts
@@ -1,0 +1,44 @@
+import { callAgentReview } from './agentReview.js';
+
+export interface MultiAgentResult {
+  decision: 'APPROVED' | 'REJECTED';
+  agentVotes: (string | undefined)[];
+  notes: string[];
+}
+
+interface Options {
+  deterministic?: boolean;
+}
+
+export async function multiAgentReview(
+  epicContent: string,
+  options: Options = {}
+): Promise<MultiAgentResult> {
+  if (!epicContent || epicContent.trim() === '') {
+    return {
+      decision: 'REJECTED',
+      agentVotes: [],
+      notes: ['Malformed epic input'],
+    };
+  }
+
+  const agentNames = ['Claude', 'Gemini', 'GPT-4', 'Custom'];
+  const names = options.deterministic ? [...agentNames].sort() : agentNames;
+
+  const votes: (string | undefined)[] = [];
+  const notes: string[] = [];
+
+  for (const name of names) {
+    const { vote, note } = await callAgentReview(name, epicContent);
+    votes.push(vote);
+    notes.push(note ?? '');
+  }
+
+  const yes = votes.filter((v) => v === 'APPROVED').length;
+  const no = votes.filter((v) => v === 'REJECTED').length;
+
+  const decision: 'APPROVED' | 'REJECTED' =
+    yes > no ? 'APPROVED' : 'REJECTED';
+
+  return { decision, agentVotes: votes, notes };
+}


### PR DESCRIPTION
## Summary
- add multiAgentReview implementation stub and agent review helper
- cover voting logic and edge cases in new Jest tests

## Testing
- `npm test --silent` *(fails: Jest requires ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_6864ae42a6a0832c9a847a76081d3b2f