### PR TITLE
Add error handling tests for applyEpic

### DIFF
--- a/__tests__/apply.test.ts
+++ b/__tests__/apply.test.ts
@@ -1,0 +1,166 @@
+import { jest } from '@jest/globals';
+
+jest.mock('fs', () => ({
+  promises: {
+    readFile: jest.fn(),
+    writeFile: jest.fn(),
+    mkdir: jest.fn(),
+  },
+}));
+
+jest.mock('../src/utils/parseEpic.js', () => ({
+  parseEpic: jest.fn(),
+}));
+
+jest.mock('../src/utils/logger.js', () => ({
+  logInfo: jest.fn(),
+  logError: jest.fn(),
+  logSuccessFinal: jest.fn(),
+  logDryRunNotice: jest.fn(),
+  logWarn: jest.fn(),
+  logCooldownWarning: jest.fn(),
+}));
+
+jest.mock('../src/utils/pasteLog.js', () => ({
+  writePasteLog: jest.fn(),
+}));
+
+jest.mock('../src/utils/cooldown.js', () => ({
+  isInCooldown: jest.fn().mockResolvedValue(false),
+}));
+
+jest.mock('../src/utils/telemetry.js', () => ({
+  recordSuccess: jest.fn(),
+  recordFailure: jest.fn(),
+  getCooldownReason: jest.fn().mockResolvedValue(null),
+}));
+
+import { promises as fs } from 'fs';
+import { parseEpic } from '../src/utils/parseEpic.js';
+import * as logger from '../src/utils/logger.js';
+import { applyEpic } from '../src/commands/apply.js';
+import * as telemetry from '../src/utils/telemetry.js';
+import { isInCooldown } from '../src/utils/cooldown.js';
+
+const readFileMock = fs.readFile as jest.Mock;
+const writeFileMock = fs.writeFile as jest.Mock;
+const parseEpicMock = parseEpic as jest.Mock;
+const logErrorMock = logger.logError as jest.Mock;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  (isInCooldown as jest.Mock).mockResolvedValue(false);
+});
+
+function epicObj(edits: any[] = []) {
+  return { summary: 'sum', edits };
+}
+
+function edit(file: string) {
+  return { filePath: file, type: 'replace', target: ['a'], replacement: ['b'] };
+}
+
+/** Test 1 */
+test('gracefully handles invalid epic', async () => {
+  readFileMock.mockResolvedValue('bad');
+  parseEpicMock.mockReturnValueOnce(null);
+
+  await expect(applyEpic('e.md', {})).resolves.toBeUndefined();
+
+  expect(logErrorMock).toHaveBeenCalled();
+  expect(telemetry.recordFailure).toHaveBeenCalled();
+  expect(writeFileMock).not.toHaveBeenCalled();
+});
+
+/** Test 2 */
+test('logs error if readFile throws', async () => {
+  readFileMock.mockRejectedValueOnce(new Error('read fail'));
+
+  await expect(applyEpic('e.md', {})).resolves.toBeUndefined();
+
+  expect(logErrorMock).toHaveBeenCalledWith(expect.stringContaining('read fail'));
+  expect(telemetry.recordFailure).toHaveBeenCalled();
+});
+
+/** Test 3 */
+test('exits cleanly if write fails non-atomic', async () => {
+  readFileMock.mockResolvedValueOnce('md'); // epic file
+  readFileMock.mockResolvedValueOnce(Buffer.from('a')); // a.txt
+  readFileMock.mockResolvedValueOnce(Buffer.from('b')); // b.txt
+  parseEpicMock.mockReturnValueOnce(epicObj([edit('a.txt'), edit('b.txt')]));
+  writeFileMock.mockResolvedValueOnce(null);
+  writeFileMock.mockRejectedValueOnce(new Error('boom'));
+
+  await expect(applyEpic('e.md', {})).resolves.toBeUndefined();
+
+  expect(logErrorMock).toHaveBeenCalledWith(expect.stringContaining('boom'));
+  expect(telemetry.recordFailure).toHaveBeenCalled();
+});
+
+/** Test 4 */
+test('atomic rollback on write failure', async () => {
+  readFileMock.mockResolvedValueOnce('md');
+  readFileMock.mockResolvedValueOnce(Buffer.from('a')); // a.txt
+  readFileMock.mockResolvedValueOnce(Buffer.from('b')); // b.txt
+  parseEpicMock.mockReturnValueOnce(epicObj([edit('a.txt'), edit('b.txt')]));
+  writeFileMock.mockResolvedValueOnce(null); // a.txt apply
+  writeFileMock.mockRejectedValueOnce(new Error('oops')); // b.txt apply
+  writeFileMock.mockResolvedValue(null); // rollbacks
+
+  await expect(applyEpic('e.md', { atomic: true })).resolves.toBeUndefined();
+
+  expect(logErrorMock).toHaveBeenCalledWith(expect.stringContaining('oops'));
+  expect(logErrorMock).toHaveBeenCalledWith('Rolled back changes due to failure');
+  expect(writeFileMock).toHaveBeenCalledTimes(4);
+});
+
+/** Test 5 */
+test('throws friendly error on unsupported edit', async () => {
+  readFileMock.mockResolvedValueOnce('md');
+  readFileMock.mockResolvedValueOnce(Buffer.from('a'));
+  parseEpicMock.mockReturnValueOnce(epicObj([{ filePath: 'x', type: 'weird', target: [], replacement: [] }]));
+
+  await expect(applyEpic('e.md', {})).rejects.toThrow();
+});
+
+/** Test 6 */
+test('logs stack trace only in debug', async () => {
+  const err = new Error('fail');
+  parseEpicMock.mockImplementationOnce(() => { throw err; });
+  readFileMock.mockResolvedValueOnce('md');
+
+  process.env.NODE_ENV = 'production';
+  await expect(applyEpic('e.md', {})).resolves.toBeUndefined();
+  expect(logErrorMock).toHaveBeenCalledWith(err.message);
+
+  jest.resetAllMocks();
+  parseEpicMock.mockImplementationOnce(() => { throw err; });
+  readFileMock.mockResolvedValueOnce('md');
+
+  process.env.NODE_ENV = 'debug';
+  await expect(applyEpic('e.md', {})).resolves.toBeUndefined();
+  expect(logErrorMock).toHaveBeenCalledWith(err.stack);
+});
+
+/** Test 7 */
+test('fallback logging if logger fails', async () => {
+  readFileMock.mockResolvedValue('md');
+  parseEpicMock.mockImplementation(() => { throw new Error('bad'); });
+  (logger.logError as jest.Mock).mockImplementationOnce(() => { throw new Error('logger'); });
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  await expect(applyEpic('e.md', {})).resolves.toBeUndefined();
+
+  expect(consoleSpy).toHaveBeenCalled();
+  consoleSpy.mockRestore();
+});
+
+/** Test 8 */
+test('suggests dry-run on failure', async () => {
+  readFileMock.mockRejectedValueOnce(new Error('fail')); // reading epic
+
+  await expect(applyEpic('e.md', {})).resolves.toBeUndefined();
+
+  expect(logErrorMock).toHaveBeenCalledWith(expect.stringContaining('Try running with --dry-run to debug'));
+});
+


### PR DESCRIPTION
## Summary
- add comprehensive tests covering failures in applyEpic

## Testing
- `npm test` *(fails: Jest cannot run because ts-node is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6864ae8abf4c832c9e02b20d841b9ab5