### PR TITLE
Add diff rendering tests

### DIFF
--- a/__tests__/__snapshots__/printUnifiedDiff.test.ts.snap
+++ b/__tests__/__snapshots__/printUnifiedDiff.test.ts.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`handles addition-only diffs 1`] = `
+"- before/file.txt
++ after/file.txt
+
+  a
++ b
+  c"
+`;
+
+exports[`handles changes and reorderings 1`] = `
+"- before/file.txt
++ after/file.txt
+
++ c
+  a
+  b
+- c"
+`;
+
+exports[`handles removal-only diffs 1`] = `
+"- before/file.txt
++ after/file.txt
+
+  a
+- b
+  c"
+`;
+
+exports[`outputs a valid unified diff when strings differ 1`] = `
+"- before/file.txt
++ after/file.txt
+
+  a
+- line2
++ line3"
+`;

--- a/__tests__/apply.test.ts
+++ b/__tests__/apply.test.ts
@@ -1,0 +1,73 @@
+import * as fs from 'fs';
+import { parseEpic } from '../src/utils/parseEpic.js';
+import { isInCooldown } from '../src/utils/cooldown.js';
+
+let diffUtil: { printUnifiedDiff: jest.Mock };
+let applyEpic: (file: string, opts: any) => Promise<void>;
+
+beforeAll(async () => {
+  jest.mock('chalk', () => ({ default: { red: jest.fn(() => ''), green: jest.fn(() => ''), yellow: jest.fn(() => ''), blue: jest.fn(() => ''), cyan: jest.fn(() => ''), magenta: jest.fn(() => '') } }), { virtual: true });
+  diffUtil = await import('../src/utils/printUnifiedDiff.js') as any;
+  applyEpic = (await import('../src/commands/apply.js')).applyEpic;
+});
+
+jest.mock('../src/utils/logger.ts', () => ({
+  __esModule: true,
+  logInfo: jest.fn(),
+  logError: jest.fn(),
+  logSuccessFinal: jest.fn(),
+  logDryRunNotice: jest.fn(),
+  logWarn: jest.fn(),
+  logCooldownWarning: jest.fn(),
+}));
+
+jest.mock('fs', () => ({ promises: { readFile: jest.fn(), writeFile: jest.fn() } }));
+jest.mock('../src/utils/parseEpic.js');
+jest.mock('../src/utils/pasteLog.ts', () => ({ __esModule: true, writePasteLog: jest.fn() }));
+jest.mock('../src/utils/telemetry.ts', () => ({
+  __esModule: true,
+  recordSuccess: jest.fn().mockResolvedValue(undefined),
+  recordFailure: jest.fn().mockResolvedValue(undefined),
+  getCooldownReason: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../src/utils/cooldown.js');
+
+const fsPromises = (fs as any).promises;
+
+beforeEach(() => {
+  (isInCooldown as jest.Mock).mockResolvedValue(false);
+  (fsPromises.readFile as jest.Mock).mockReset();
+  (fsPromises.writeFile as jest.Mock).mockReset();
+});
+
+test('when diff flag is true, printUnifiedDiff is called with correct args', async () => {
+  (parseEpic as jest.Mock).mockReturnValue({
+    summary: 's',
+    edits: [
+      { filePath: 'file.txt', type: 'replace', target: ['old'], replacement: ['new'] },
+    ],
+  });
+  (fsPromises.readFile as jest.Mock).mockResolvedValueOnce('md').mockResolvedValueOnce('old');
+  const diffSpy = jest.spyOn(diffUtil, 'printUnifiedDiff').mockImplementation(() => {});
+
+  await applyEpic('e.md', { diff: true });
+
+  expect(diffSpy).toHaveBeenCalledWith('old', 'new', 'file.txt');
+  diffSpy.mockRestore();
+});
+
+test('when diff flag is false, diff is not generated', async () => {
+  (parseEpic as jest.Mock).mockReturnValue({
+    summary: 's',
+    edits: [
+      { filePath: 'file.txt', type: 'replace', target: ['old'], replacement: ['new'] },
+    ],
+  });
+  (fsPromises.readFile as jest.Mock).mockResolvedValueOnce('md').mockResolvedValueOnce('old');
+  const diffSpy = jest.spyOn(diffUtil, 'printUnifiedDiff').mockImplementation(() => {});
+
+  await applyEpic('e.md', { diff: false });
+
+  expect(diffSpy).not.toHaveBeenCalled();
+  diffSpy.mockRestore();
+});

--- a/__tests__/printUnifiedDiff.test.ts
+++ b/__tests__/printUnifiedDiff.test.ts
@@ -1,0 +1,55 @@
+let printUnifiedDiff: (before: string, after: string, filePath: string) => void;
+
+beforeAll(async () => {
+  ({ printUnifiedDiff } = await import('../src/utils/printUnifiedDiff.js'));
+});
+
+let logSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+});
+
+test('outputs a valid unified diff when strings differ', () => {
+  printUnifiedDiff('a\nline2', 'a\nline3', 'file.txt');
+  expect(logSpy).toHaveBeenCalledTimes(1);
+  expect(logSpy.mock.calls[0][0]).toMatchSnapshot();
+});
+
+test('handles removal-only diffs', () => {
+  printUnifiedDiff('a\nb\nc', 'a\nc', 'file.txt');
+  expect(logSpy.mock.calls[0][0]).toMatchSnapshot();
+});
+
+test('handles addition-only diffs', () => {
+  printUnifiedDiff('a\nc', 'a\nb\nc', 'file.txt');
+  expect(logSpy.mock.calls[0][0]).toMatchSnapshot();
+});
+
+test('handles changes and reorderings', () => {
+  printUnifiedDiff('a\nb\nc', 'c\na\nb', 'file.txt');
+  expect(logSpy.mock.calls[0][0]).toMatchSnapshot();
+});
+
+test('does not output anything when content is unchanged', () => {
+  printUnifiedDiff('same', 'same', 'file.txt');
+  expect(logSpy).not.toHaveBeenCalled();
+});
+
+test('uses correct file path in diff header', () => {
+  printUnifiedDiff('1', '2', 'my/path.txt');
+  const output = logSpy.mock.calls[0][0] as string;
+  expect(output.startsWith('- before/my/path.txt')).toBe(true);
+});
+
+test('handles large diff gracefully', () => {
+  const before = Array.from({ length: 120 }, (_, i) => `line${i}`).join('\n');
+  const after = before + '\nextra';
+  printUnifiedDiff(before, after, 'big.txt');
+  const output = logSpy.mock.calls[0][0] as string;
+  expect(output.includes('...diff truncated...')).toBe(true);
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ export default {
   globals: {
     'ts-jest': {
       useESM: true,
+      tsconfig: { esModuleInterop: true },
     },
   },
   transform: {},

--- a/src/commands/apply.js
+++ b/src/commands/apply.js
@@ -1,0 +1,1 @@
+module.exports = require('./apply.ts');

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -10,6 +10,7 @@ import {
   logCooldownWarning,
 } from '../utils/logger.js';
 import { parseEpic, FileEdit } from '../utils/parseEpic.js';
+import { printUnifiedDiff } from "../utils/printUnifiedDiff.js";
 import { writePasteLog } from '../utils/pasteLog.js';
 import { isInCooldown } from '../utils/cooldown.js';
 import { recordSuccess, recordFailure, getCooldownReason } from '../utils/telemetry.js';
@@ -117,8 +118,8 @@ export async function applyEpic(file: string, options: ApplyOptions): Promise<vo
   try {
     for (const [absPath, data] of fileContents.entries()) {
       if (options.diff) {
-        const d = diffLines(data.original, data.updated);
-        logInfo(`Diff for ${absPath}:\n${d}`);
+        const rel = path.relative(workspace, absPath);
+        printUnifiedDiff(data.original, data.updated, rel);
       }
       if (options.atomic) {
         backups.set(absPath, data.original);

--- a/src/utils/cooldown.js
+++ b/src/utils/cooldown.js
@@ -1,0 +1,1 @@
+module.exports = require('./cooldown.ts');

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,1 @@
+module.exports = require('./logger.ts');

--- a/src/utils/parseEpic.js
+++ b/src/utils/parseEpic.js
@@ -1,0 +1,1 @@
+module.exports = require('./parseEpic.ts');

--- a/src/utils/pasteLog.js
+++ b/src/utils/pasteLog.js
@@ -1,0 +1,1 @@
+module.exports = require('./pasteLog.ts');

--- a/src/utils/printUnifiedDiff.js
+++ b/src/utils/printUnifiedDiff.js
@@ -1,0 +1,1 @@
+module.exports = require('./printUnifiedDiff.ts');

--- a/src/utils/printUnifiedDiff.ts
+++ b/src/utils/printUnifiedDiff.ts
@@ -1,0 +1,24 @@
+import { diffLinesUnified } from 'jest-diff';
+
+const MAX_LINES = 50;
+
+export function printUnifiedDiff(before: string, after: string, filePath: string): void {
+  if (before === after) return;
+
+  const diff = diffLinesUnified(
+    before.split(/\r?\n/),
+    after.split(/\r?\n/),
+    {
+      aAnnotation: `before/${filePath}`,
+      bAnnotation: `after/${filePath}`,
+    }
+  );
+
+  if (!diff) return;
+  const lines = diff.split('\n');
+  let output = diff;
+  if (lines.length > MAX_LINES) {
+    output = lines.slice(0, MAX_LINES).join('\n') + '\n...diff truncated...';
+  }
+  console.log(output);
+}

--- a/src/utils/telemetry.js
+++ b/src/utils/telemetry.js
@@ -1,0 +1,1 @@
+module.exports = require('./telemetry.ts');


### PR DESCRIPTION
## Summary
- implement unified diff utility and integrate in apply command
- add Jest tests for printUnifiedDiff output
- test applyEpic diff option wiring
- provide CJS stubs so jest can resolve modules
- switch to JS Jest config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864ae629f4c832c82e0d4c417b2e568