### PR TITLE
Add telemetry logging

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -13,7 +13,7 @@ import { parseEpic, FileEdit } from '../utils/parseEpic.js';
 import { printUnifiedDiff } from "../utils/printUnifiedDiff.js";
 import { writePasteLog } from '../utils/pasteLog.js';
 import { isInCooldown } from '../utils/cooldown.js';
-import { recordSuccess, recordFailure, getCooldownReason } from '../utils/telemetry.js';
+import { recordSuccess, recordFailure, getCooldownReason, logTelemetry } from '../utils/telemetry.js';
 
 interface ApplyOptions {
   dryRun?: boolean;
@@ -71,6 +71,11 @@ function diffLines(oldStr: string, newStr: string): string {
 }
 
 export async function applyEpic(file: string, options: ApplyOptions): Promise<void> {
+  await logTelemetry({
+    command: 'applyEpic',
+    timestamp: Date.now(),
+    flags: Object.keys(options || {}),
+  });
   if (await isInCooldown()) {
     logCooldownWarning();
     const reason = await getCooldownReason();

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -6,7 +6,7 @@ import {
   logSuccessFinal,
   logCooldownWarning,
 } from '../utils/logger.js';
-import { recordFailure, recordSuccess, getCooldownReason } from '../utils/telemetry.js';
+import { recordFailure, recordSuccess, getCooldownReason, logTelemetry } from '../utils/telemetry.js';
 import { isInCooldown } from '../utils/cooldown.js';
 import { validateSchema } from '../utils/validateSchema.js';
 import { multiAgentReview, CouncilVerdict } from '../utils/multiAgentReview.js';
@@ -16,6 +16,11 @@ interface ValidateOptions {
 }
 
 export async function validateEpic(epicFilePath: string, options: ValidateOptions): Promise<void> {
+  await logTelemetry({
+    command: 'validateEpic',
+    timestamp: Date.now(),
+    flags: Object.keys(options || {}),
+  });
   if (await isInCooldown()) {
     logCooldownWarning();
     const reason = await getCooldownReason();

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -107,3 +107,20 @@ export async function getCooldownReason(): Promise<string | null> {
   }
   return null;
 }
+
+export interface TelemetryEntry {
+  command: string;
+  timestamp: number;
+  flags?: string[];
+}
+
+export async function logTelemetry(entry: TelemetryEntry): Promise<void> {
+  const dir = path.join(process.cwd(), '.uado');
+  const file = path.join(dir, 'telemetry.jsonl');
+  try {
+    await fs.mkdir(dir, { recursive: true });
+    await fs.appendFile(file, JSON.stringify(entry) + '\n', 'utf8');
+  } catch {
+    // fail silently
+  }
+}


### PR DESCRIPTION
## Summary
- add `logTelemetry` util for jsonl log
- call `logTelemetry` in `applyEpic` and `validateEpic`

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token '/')*

------
https://chatgpt.com/codex/tasks/task_e_6864b43804c0832cb9fa53ae9c1c87be