### PR TITLE
Refactor runtime logging

### DIFF
--- a/__tests__/runtimeLog.test.ts
+++ b/__tests__/runtimeLog.test.ts
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 import path from 'path';
 import { promises as fs } from 'fs';
 import { runtimeLog } from '../src/utils/runtimeLog.js';
+import { getUadoDir } from '../src/utils/getUadoDir.js';
 
 jest.mock('fs', () => ({
   promises: {
@@ -19,7 +20,7 @@ beforeEach(() => {
 
 test('logs structured entry', async () => {
   await runtimeLog('applyEpic', { foo: 'bar' }, null, null);
-  const dir = path.join(process.cwd(), '.uado');
+  const dir = getUadoDir();
   const file = path.join(dir, 'runtime.json');
   expect(mkdirMock).toHaveBeenCalledWith(dir, { recursive: true });
   expect(appendFileMock).toHaveBeenCalledWith(file, expect.any(String), 'utf8');

--- a/__tests__/telemetry.test.ts
+++ b/__tests__/telemetry.test.ts
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 import path from 'path';
 import { promises as fs } from 'fs';
 import { logTelemetry } from '../src/utils/telemetry.js';
+import { getUadoDir } from '../src/utils/getUadoDir.js';
 
 jest.mock('chalk', () => ({
   __esModule: true,
@@ -33,7 +34,7 @@ test('logs a valid entry with command and timestamp', async () => {
   const entry = { command: 'apply', timestamp: 123, flags: ['--dry-run'] };
   await expect(logTelemetry(entry)).resolves.toBeUndefined();
 
-  const dir = path.join(process.cwd(), '.uado');
+  const dir = getUadoDir();
   const file = path.join(dir, 'telemetry.jsonl');
   expect(mkdirMock).toHaveBeenCalledWith(dir, { recursive: true });
   expect(appendFileMock).toHaveBeenCalledWith(file, JSON.stringify(entry) + '\n', 'utf8');
@@ -43,7 +44,7 @@ test('creates .uado directory and file if missing', async () => {
   const entry = { command: 'validate', timestamp: 456 };
   await logTelemetry(entry);
 
-  const dir = path.join(process.cwd(), '.uado');
+  const dir = getUadoDir();
   const file = path.join(dir, 'telemetry.jsonl');
   expect(mkdirMock).toHaveBeenCalledWith(dir, { recursive: true });
   expect(appendFileMock).toHaveBeenCalledWith(file, JSON.stringify(entry) + '\n', 'utf8');
@@ -55,7 +56,7 @@ test('appends multiple entries', async () => {
   await logTelemetry(e1);
   await logTelemetry(e2);
 
-  const dir = path.join(process.cwd(), '.uado');
+  const dir = getUadoDir();
   const file = path.join(dir, 'telemetry.jsonl');
   expect(appendFileMock).toHaveBeenCalledTimes(2);
   expect(appendFileMock).toHaveBeenNthCalledWith(1, file, JSON.stringify(e1) + '\n', 'utf8');

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,5 +12,6 @@ export default {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
+  moduleFileExtensions: ['ts', 'js', 'json', 'node'],
   testMatch: ['**/__tests__/**/*.test.ts'],
 };

--- a/src/utils/getUadoDir.js
+++ b/src/utils/getUadoDir.js
@@ -1,0 +1,1 @@
+export { getUadoDir } from './getUadoDir.ts';

--- a/src/utils/getUadoDir.ts
+++ b/src/utils/getUadoDir.ts
@@ -1,0 +1,5 @@
+import path from 'path';
+
+export function getUadoDir(): string {
+  return process.env.UADO_DIR || path.join(process.cwd(), '.uado');
+}

--- a/src/utils/runtimeLog.js
+++ b/src/utils/runtimeLog.js
@@ -1,1 +1,1 @@
-module.exports = require('./runtimeLog.ts');
+export { runtimeLog } from './runtimeLog.ts';

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import { getUadoDir } from './getUadoDir.js';
 import { readPasteLog } from './pasteLog.js';
 
 export interface TelemetryState {
@@ -115,7 +116,7 @@ export interface TelemetryEntry {
 }
 
 export async function logTelemetry(entry: TelemetryEntry): Promise<void> {
-  const dir = path.join(process.cwd(), '.uado');
+  const dir = getUadoDir();
   const file = path.join(dir, 'telemetry.jsonl');
   try {
     await fs.mkdir(dir, { recursive: true });


### PR DESCRIPTION
## Summary
- centralize `.uado` directory logic via `getUadoDir`
- improve `runtimeLog` typings and debug handling
- use ESM re-export for `runtimeLog.js`
- adjust Jest config for TypeScript preference
- update tests for new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864c103a824832cb349280515bafc34