### PR TITLE
Introduce structured error codes

### DIFF
--- a/__tests__/runtimeLog.test.ts
+++ b/__tests__/runtimeLog.test.ts
@@ -29,15 +29,17 @@ test('logs structured entry', async () => {
   expect(entry.args).toEqual({ foo: 'bar' });
   expect(entry.cooldownReason).toBeNull();
   expect(entry.error).toBeNull();
+  expect(entry.errorCode).toBeUndefined();
   expect(typeof entry.timestamp).toBe('string');
   expect(result).toEqual(entry);
 });
 
 test('includes cooldown and error', async () => {
-  await runtimeLog('validateEpic', { id: 1 }, 'cool', 'boom');
+  await runtimeLog('validateEpic', { id: 1 }, 'cool', 'boom', 'E002');
   const entry = JSON.parse(appendFileMock.mock.calls[0][1].trim());
   expect(entry.cooldownReason).toBe('cool');
   expect(entry.error).toBe('boom');
+  expect(entry.errorCode).toBe('E002');
   expect(entry.commandName).toBe('validateEpic');
 });
 

--- a/src/constants/errorCodes.ts
+++ b/src/constants/errorCodes.ts
@@ -1,0 +1,9 @@
+export const ErrorCodes = Object.freeze({
+  INVALID_EPIC: 'E001',
+  FILE_READ_FAIL: 'E002',
+  WRITE_FAIL: 'E003',
+  UNSUPPORTED_EDIT: 'E004',
+  COOLDOWN_ACTIVE: 'E005',
+  VALIDATION_REJECTED: 'E006',
+} as const);
+export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];

--- a/src/utils/runtimeLog.ts
+++ b/src/utils/runtimeLog.ts
@@ -10,6 +10,7 @@ export interface RuntimeLogEntry<T = unknown> {
   args: T;
   cooldownReason: string | null;
   error: string | null;
+  errorCode?: string;
 }
 
 const DIR = getUadoDir();
@@ -19,7 +20,8 @@ export async function runtimeLog<T = unknown>(
   commandName: CommandName,
   args: T,
   cooldownReason: string | null,
-  error: string | null
+  error: string | null,
+  errorCode?: string
 ): Promise<RuntimeLogEntry<T>> {
   const entry: RuntimeLogEntry<T> = {
     timestamp: new Date().toISOString(),
@@ -27,6 +29,7 @@ export async function runtimeLog<T = unknown>(
     args,
     cooldownReason,
     error,
+    errorCode,
   };
   try {
     await fs.mkdir(DIR, { recursive: true });

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -68,7 +68,7 @@ async function checkConditions(state: TelemetryState): Promise<void> {
   }
 }
 
-export async function recordFailure(): Promise<void> {
+export async function recordFailure(_error?: { message: string; code: string }): Promise<void> {
   const state = await readState();
   state.consecutiveFailures += 1;
   state.lastRun = new Date().toISOString();


### PR DESCRIPTION
## Summary
- define shared `ErrorCodes` constants
- record optional `errorCode` in runtime logging
- propagate structured errors through applyEpic and validateEpic
- update telemetry to accept error data
- adjust unit tests for new codes

## Testing
- `npx jest --config jest.config.js`

------
https://chatgpt.com/codex/tasks/task_e_6864d0b2b198832cbf973ad8b9d77cc2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced standardized error codes for various failure scenarios, enhancing error reporting consistency across the application.
  * Error logs, telemetry, and runtime logs now include both error messages and corresponding error codes for improved traceability.

* **Refactor**
  * Updated error handling in core commands to use structured error objects containing both messages and error codes.

* **Tests**
  * Enhanced test suites to verify the presence and correctness of error codes in logs and telemetry records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->