### PR TITLE
Enhance summary logging output

### DIFF
--- a/__tests__/apply.test.ts
+++ b/__tests__/apply.test.ts
@@ -27,15 +27,19 @@ jest.mock('../src/utils/parseEpic.js', () => ({
   parseEpic: jest.fn(),
 }));
 
-jest.mock('../src/utils/logger.js', () => ({
-  logInfo: jest.fn(),
-  logError: jest.fn(),
-  logSuccessFinal: jest.fn(),
-  logDryRunNotice: jest.fn(),
-  logWarn: jest.fn(),
-  logCooldownWarning: jest.fn(),
-  setQuiet: jest.fn(),
-}));
+jest.mock('../src/utils/logger.js', () => {
+  const actual = jest.requireActual('../src/utils/logger.js');
+  return {
+    ...actual,
+    logInfo: jest.fn(),
+    logError: jest.fn(),
+    logSuccessFinal: jest.fn(),
+    logDryRunNotice: jest.fn(),
+    logWarn: jest.fn(),
+    logCooldownWarning: jest.fn(),
+    setQuiet: jest.fn(),
+  };
+});
 
 jest.mock('../src/utils/telemetry.js', () => ({
   recordSuccess: jest.fn(),
@@ -197,7 +201,8 @@ test('summary mode outputs json only', async () => {
   parseEpicMock.mockReturnValueOnce(epicObj([]));
   const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
   await expect(applyEpic('e.md', { summary: true })).resolves.toBeUndefined();
-  expect(consoleSpy).toHaveBeenCalledWith(JSON.stringify({ success: true }));
+  const output = consoleSpy.mock.calls[0][0];
+  expect(output).toContain('Summary:');
   expect(logger.logSuccessFinal).not.toHaveBeenCalled();
   expect(logger.logInfo).not.toHaveBeenCalled();
   consoleSpy.mockRestore();

--- a/__tests__/logger.test.ts
+++ b/__tests__/logger.test.ts
@@ -1,0 +1,31 @@
+import { jest } from '@jest/globals';
+import { logSummary } from '../src/utils/logger.js';
+
+jest.mock('chalk', () => ({
+  __esModule: true,
+  default: {
+    yellow: (s: any) => s,
+    red: (s: any) => s,
+    green: (s: any) => s,
+    gray: (s: any) => s,
+    cyan: (s: any) => s,
+  },
+}));
+
+test('logSummary groups by file and counts outcomes', () => {
+  const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  logSummary({
+    success: true,
+    files: [
+      { filePath: 'a.txt', edits: [{ type: 'replace' }, { type: 'insert-before', skipped: true }] },
+      { filePath: 'b.txt', edits: [{ type: 'delete' }] },
+    ],
+  });
+  expect(spy).toHaveBeenCalledTimes(1);
+  const out = spy.mock.calls[0][0];
+  expect(out).toContain('📄 a.txt');
+  expect(out).toContain('✅ replace');
+  expect(out).toContain('⚪ insert-before');
+  expect(out).toContain('Summary: 2 files updated, 1 edits skipped, 0 errors');
+  spy.mockRestore();
+});

--- a/__tests__/validate.test.ts
+++ b/__tests__/validate.test.ts
@@ -11,13 +11,17 @@ import { ErrorCodes } from '../src/constants/errorCodes.js';
 jest.mock('chalk', () => ({__esModule: true, default: {red:(s:any)=>s, green:(s:any)=>s, cyan:(s:any)=>s, yellow:(s:any)=>s, blue:(s:any)=>s, magenta:(s:any)=>s}}));
 
 jest.mock('fs', () => ({ promises: { readFile: jest.fn(), appendFile: jest.fn(), mkdir: jest.fn() } }));
-jest.mock('../src/utils/logger', () => ({
-  logInfo: jest.fn(),
-  logError: jest.fn(),
-  logSuccessFinal: jest.fn(),
-  logCooldownWarning: jest.fn(),
-  setQuiet: jest.fn(),
-}));
+jest.mock('../src/utils/logger', () => {
+  const actual = jest.requireActual('../src/utils/logger.js');
+  return {
+    ...actual,
+    logInfo: jest.fn(),
+    logError: jest.fn(),
+    logSuccessFinal: jest.fn(),
+    logCooldownWarning: jest.fn(),
+    setQuiet: jest.fn(),
+  };
+});
 jest.mock('../src/utils/cooldown', () => ({ isInCooldown: jest.fn() }));
 jest.mock('../src/utils/multiAgentReview', () => ({
   multiAgentReview: jest.fn(),
@@ -113,7 +117,8 @@ describe('validateEpic', () => {
     readFileMock.mockResolvedValueOnce(JSON.stringify(validEpic));
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     await validateEpic('epic.json', { summary: true });
-    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ success: true }));
+    const output = logSpy.mock.calls[0][0];
+    expect(output).toContain('Summary:');
     expect(logSuccessFinal).not.toHaveBeenCalled();
     expect(logInfo).not.toHaveBeenCalled();
     logSpy.mockRestore();

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -5,6 +5,7 @@ import {
   logError,
   logSuccessFinal,
   logCooldownWarning,
+  logSummary,
   setQuiet,
 } from '../utils/logger.js';
 import { recordFailure, recordSuccess, getCooldownReason, logTelemetry } from '../utils/telemetry.js';
@@ -41,7 +42,10 @@ export async function validateEpic(epicFilePath: string, options: ValidateOption
       logCooldownWarning();
       if (cooldownReason) logInfo(`Reason: ${cooldownReason}`);
     }
-    if (summary) console.log(JSON.stringify({ success, error: error.message, code: error.code }));
+    if (summary) {
+      const reason = cooldownReason ? `Cooldown active: ${cooldownReason}` : 'Cooldown active';
+      logSummary({ success, files: [], cooldown: reason });
+    }
     return;
   }
 
@@ -56,7 +60,7 @@ export async function validateEpic(epicFilePath: string, options: ValidateOption
     process.exitCode = 1;
     await runtimeLog('validateEpic', { epicFilePath, options }, cooldownReason, error.message, error.code);
     success = false;
-    if (summary) console.log(JSON.stringify({ success, error: error.message, code: error.code }));
+    if (summary) logSummary({ success, files: [], error: error.message });
     return;
   }
 
@@ -70,7 +74,7 @@ export async function validateEpic(epicFilePath: string, options: ValidateOption
     process.exitCode = 1;
     await runtimeLog('validateEpic', { epicFilePath, options }, cooldownReason, error.message, error.code);
     success = false;
-    if (summary) console.log(JSON.stringify({ success, error: error.message, code: error.code }));
+    if (summary) logSummary({ success, files: [], error: error.message });
     return;
   }
 
@@ -81,7 +85,7 @@ export async function validateEpic(epicFilePath: string, options: ValidateOption
     await recordFailure(error);
     process.exitCode = 1;
     success = false;
-    if (summary) console.log(JSON.stringify({ success, error: error.message, code: error.code }));
+    if (summary) logSummary({ success, files: [], error: error.message });
     return;
   }
 
@@ -98,11 +102,11 @@ export async function validateEpic(epicFilePath: string, options: ValidateOption
       await recordFailure(error);
       process.exitCode = 1;
       success = false;
-      if (summary) console.log(JSON.stringify({ success, error: error.message, code: error.code }));
+      if (summary) logSummary({ success, files: [], error: error.message });
       return;
     }
     if (!summary && !silent) logInfo('Council approved this epic.');
   }
 
-  if (summary) console.log(JSON.stringify({ success: true }));
+  if (summary) logSummary({ success: true, files: [] });
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -54,3 +54,46 @@ export function logDryRunNotice(): void {
   if (quiet) return;
   console.log(chalk.yellow('🚧 Dry-run mode enabled. No changes were written.'));
 }
+
+export interface LogSummaryFile {
+  filePath: string;
+  edits: { type: string; skipped?: boolean }[];
+}
+
+export interface LogSummaryOptions {
+  success: boolean;
+  files?: LogSummaryFile[];
+  cooldown?: string | null;
+  error?: string | null;
+}
+
+export function logSummary(opts: LogSummaryOptions): void {
+  const lines: string[] = [];
+
+  if (opts.cooldown) {
+    lines.push(chalk.yellow(`⚠️ ${opts.cooldown}`));
+  }
+
+  const files = opts.files ?? [];
+  for (const f of files) {
+    lines.push(`📄 ${f.filePath}`);
+    for (const e of f.edits) {
+      const color = e.skipped ? chalk.gray : chalk.green;
+      const icon = e.skipped ? '⚪' : '✅';
+      lines.push(`  ${color(`${icon} ${e.type}`)}`);
+    }
+  }
+
+  if (opts.error) {
+    lines.push(chalk.red(`❌ ${opts.error}`));
+  }
+
+  const fileCount = files.length;
+  const skipped = files.reduce((acc, f) => acc + f.edits.filter(e => e.skipped).length, 0);
+  const errorCount = opts.error ? 1 : 0;
+  lines.push(
+    `Summary: ${fileCount} files updated, ${skipped} edits skipped, ${errorCount} error${errorCount === 1 ? '' : 's'}`
+  );
+
+  console.log(lines.join('\n'));
+}


### PR DESCRIPTION
## Summary
- add `logSummary` for colorful grouped summaries with counts
- display summary output in `applyEpic` and `validateEpic`
- update tests for new summary formatting
- add unit tests for `logSummary`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864d41a616c832caeb6ae07951dc1d5