### PR TITLE
Improve RunSafe CLI output

### DIFF
--- a/__tests__/apply.test.ts
+++ b/__tests__/apply.test.ts
@@ -202,7 +202,7 @@ test('summary mode outputs json only', async () => {
   const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
   await expect(applyEpic('e.md', { summary: true })).resolves.toBeUndefined();
   const output = consoleSpy.mock.calls[0][0];
-  expect(output).toContain('Summary:');
+  expect(output).toContain('✅ 0 applied');
   expect(logger.logSuccessFinal).not.toHaveBeenCalled();
   expect(logger.logInfo).not.toHaveBeenCalled();
   consoleSpy.mockRestore();

--- a/__tests__/logger.test.ts
+++ b/__tests__/logger.test.ts
@@ -12,20 +12,26 @@ jest.mock('chalk', () => ({
   },
 }));
 
-test('logSummary groups by file and counts outcomes', () => {
+test('logSummary lists groups and footer counts', () => {
   const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
   logSummary({
     success: true,
     files: [
-      { filePath: 'a.txt', edits: [{ type: 'replace' }, { type: 'insert-before', skipped: true }] },
-      { filePath: 'b.txt', edits: [{ type: 'delete' }] },
+      { filePath: 'a.txt', edits: [{ type: 'replace' }] },
+      { filePath: 'b.txt', edits: [{ type: 'delete', skipped: true }] },
     ],
+    error: 'oops',
   });
   expect(spy).toHaveBeenCalledTimes(1);
   const out = spy.mock.calls[0][0];
-  expect(out).toContain('📄 a.txt');
-  expect(out).toContain('✅ replace');
-  expect(out).toContain('⚪ insert-before');
-  expect(out).toContain('Summary: 2 files updated, 1 edits skipped, 0 errors');
+  expect(out).toContain('📝 Modified Files');
+  expect(out).toContain('- a.txt');
+  expect(out).toContain('⚠️ Skipped Edits');
+  expect(out).toContain('- b.txt');
+  expect(out).toContain('❌ Errors');
+  expect(out).toContain('oops');
+  expect(out).toContain('✅ 1 applied');
+  expect(out).toContain('⚠️ 1 skipped');
+  expect(out).toContain('❌ 1 error');
   spy.mockRestore();
 });

--- a/__tests__/validate.test.ts
+++ b/__tests__/validate.test.ts
@@ -115,14 +115,14 @@ describe('validateEpic', () => {
 
   it('Summary mode outputs json only', async () => {
     readFileMock.mockResolvedValueOnce(JSON.stringify(validEpic));
-    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-    await validateEpic('epic.json', { summary: true });
-    const output = logSpy.mock.calls[0][0];
-    expect(output).toContain('Summary:');
-    expect(logSuccessFinal).not.toHaveBeenCalled();
-    expect(logInfo).not.toHaveBeenCalled();
-    logSpy.mockRestore();
-  });
+  const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  await validateEpic('epic.json', { summary: true });
+  const output = logSpy.mock.calls[0][0];
+  expect(output).toContain('✅ 0 applied');
+  expect(logSuccessFinal).not.toHaveBeenCalled();
+  expect(logInfo).not.toHaveBeenCalled();
+  logSpy.mockRestore();
+});
 
   it('Silent mode suppresses logs but shows errors', async () => {
     readFileMock.mockRejectedValueOnce(new Error('nope'));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,13 @@
 
 import { Command } from 'commander';
 import { loadConfig } from './utils/config.js';
-import { logInfo, logError, logBanner, logWelcome, setQuiet } from './utils/logger.js';
+import {
+  logInfo,
+  logError,
+  logBanner,
+  logWelcome,
+  setQuiet,
+} from './utils/logger.js';
 import { applyEpic } from './commands/apply.js';
 import { validateEpic } from './commands/validate.js';
 import { runDoctor } from './commands/doctor.js';
@@ -28,6 +34,10 @@ function showWelcome() {
   logWelcome(msg);
 }
 
+function showIntro() {
+  logBanner('🛡️  RunSafe CLI v0.1  —  Secure AI Dev, One Command at a Time');
+}
+
 export async function run(argv: string[]): Promise<void> {
   const program = new Command();
 
@@ -36,6 +46,10 @@ export async function run(argv: string[]): Promise<void> {
 
   const quietFlag = argv.includes('--quiet') || argv.includes('-q');
   if (quietFlag) setQuiet(true);
+
+  if (!quietFlag) {
+    showIntro();
+  }
 
   const noArgs = argv.length <= 2;
   const first = await checkFirstRun();
@@ -52,7 +66,7 @@ export async function run(argv: string[]): Promise<void> {
 
   program.addHelpText(
     'after',
-    '\nExamples:\n  $ runsafe apply epic-001.md --dry-run\n  $ runsafe validate epic-001.md --council\n  $ runsafe uado doctor'
+    `\nRunSafe Commands:\n  apply <epic>     Apply file edits from epic markdown\n  validate <epic>  Validate epic markdown\n  uado doctor      Show recent run health summary\n\nFlags:\n  --summary  output json summary only\n  --silent   suppress all logging except errors\n  --json     output structured json\n  -q, --quiet suppress banner and logs\n\nExamples:\n  $ runsafe apply epic-001.md --dry-run\n  $ runsafe validate epic-001.md --council\n  $ runsafe uado doctor\n\n🔧 Tip: Use --json for machine-readable output`
   );
 
   program

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -79,28 +79,40 @@ export function logSummary(opts: LogSummaryOptions): void {
 
   if (opts.cooldown) {
     lines.push(chalk.yellow(`⚠️ ${opts.cooldown}`));
+    lines.push('');
   }
 
   const files = opts.files ?? [];
-  for (const f of files) {
-    lines.push(`📄 ${f.filePath}`);
-    for (const e of f.edits) {
-      const color = e.skipped ? chalk.gray : chalk.green;
-      const icon = e.skipped ? '⚪' : '✅';
-      lines.push(`  ${color(`${icon} ${e.type}`)}`);
+  const modified = files.filter(f => f.edits.some(e => !e.skipped));
+  const skipped = files.filter(f => f.edits.every(e => e.skipped));
+
+  if (modified.length > 0) {
+    lines.push('📝 Modified Files');
+    for (const f of modified) {
+      lines.push(`- ${f.filePath}`);
     }
+    lines.push('');
+  }
+
+  if (skipped.length > 0) {
+    lines.push('⚠️ Skipped Edits');
+    for (const f of skipped) {
+      lines.push(`- ${f.filePath}`);
+    }
+    lines.push('');
   }
 
   if (opts.error) {
-    lines.push(chalk.red(`❌ ${opts.error}`));
+    lines.push('❌ Errors');
+    lines.push(`- ${opts.error}`);
+    lines.push('');
   }
 
-  const fileCount = files.length;
-  const skipped = files.reduce((acc, f) => acc + f.edits.filter(e => e.skipped).length, 0);
+  const appliedCount = modified.length;
+  const skippedCount = skipped.length;
   const errorCount = opts.error ? 1 : 0;
-  lines.push(
-    `Summary: ${fileCount} files updated, ${skipped} edits skipped, ${errorCount} error${errorCount === 1 ? '' : 's'}`
-  );
+
+  lines.push(`✅ ${appliedCount} applied · ⚠️ ${skippedCount} skipped · ❌ ${errorCount} error${errorCount === 1 ? '' : 's'}`);
 
   console.log(lines.join('\n'));
 }


### PR DESCRIPTION
## Summary
- display intro banner on every run
- reorganize CLI help text with RunSafe commands and flags
- output grouped summary with counts
- update tests for new logger format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864da710acc832c9d330badbd9d6a5c