### PR TITLE
Improve cooldown and error UX

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -132,8 +132,8 @@ export async function applyEpic(file: string, options: ApplyOptions): Promise<vo
     md = await fs.readFile(epicPath, 'utf8');
   } catch (err) {
     if (!summary) {
-      logError(`[${ErrorCodes.FILE_READ_FAIL}] ${(err as Error).message}`);
-      logError('Try running with --dry-run to debug');
+      logError(`❌ [${ErrorCodes.FILE_READ_FAIL}] ${(err as Error).message}`);
+      logError('❌ Try running with --dry-run to debug');
     }
     error = { message: (err as Error).message, code: ErrorCodes.FILE_READ_FAIL };
     await recordFailure(error);
@@ -152,7 +152,7 @@ export async function applyEpic(file: string, options: ApplyOptions): Promise<vo
     const msg = process.env.NODE_ENV === 'debug' ? (err as Error).stack : (err as Error).message;
     if (!summary) {
       try {
-        logError(`[${ErrorCodes.INVALID_EPIC}] ${msg as string}`);
+        logError(`❌ [${ErrorCodes.INVALID_EPIC}] ${msg as string}`);
       } catch (logErr) {
         console.error(logErr);
       }
@@ -247,7 +247,7 @@ export async function applyEpic(file: string, options: ApplyOptions): Promise<vo
         const code = (err as Error).message.startsWith('Unsupported edit type')
           ? ErrorCodes.UNSUPPORTED_EDIT
           : ErrorCodes.WRITE_FAIL;
-        logError(`[${code}] ${(err as Error).message}`);
+        logError(`❌ [${code}] ${(err as Error).message}`);
       } catch (logErr) {
         console.error(logErr);
       }
@@ -257,7 +257,7 @@ export async function applyEpic(file: string, options: ApplyOptions): Promise<vo
         await fs.writeFile(absPath, orig, 'utf8');
       }
       try {
-        if (!summary) logError('Rolled back changes due to failure');
+        if (!summary) logError('❌ Rolled back changes due to failure');
       } catch (logErr) {
         console.error(logErr);
       }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -75,7 +75,8 @@ export async function validateEpic(epicFilePath: string, options: ValidateOption
   try {
     raw = await fs.readFile(absPath, 'utf8');
   } catch (err) {
-    if (!summary) logError(`[${ErrorCodes.FILE_READ_FAIL}] Epic file not found`);
+    if (!summary) logError(`❌ [${ErrorCodes.FILE_READ_FAIL}] Epic file not found`);
+    if (!summary) logError('💡 Tip: Use --dry-run to preview changes without applying.');
     error = { message: 'Epic file not found', code: ErrorCodes.FILE_READ_FAIL };
     await recordFailure(error);
     process.exitCode = 1;
@@ -91,7 +92,8 @@ export async function validateEpic(epicFilePath: string, options: ValidateOption
     epic = JSON.parse(raw);
     summaryText = typeof epic.summary === 'string' ? epic.summary : '';
   } catch (err) {
-    if (!summary) logError(`[${ErrorCodes.INVALID_EPIC}] Invalid JSON format`);
+    if (!summary) logError(`❌ [${ErrorCodes.INVALID_EPIC}] Invalid JSON format`);
+    if (!summary) logError('💡 Tip: Use --dry-run to preview changes without applying.');
     error = { message: 'Invalid JSON format', code: ErrorCodes.INVALID_EPIC };
     await recordFailure(error);
     process.exitCode = 1;
@@ -104,7 +106,8 @@ export async function validateEpic(epicFilePath: string, options: ValidateOption
 
   const result = validateSchema(epic);
   if (!result.valid) {
-    if (!summary) logError(`[${ErrorCodes.INVALID_EPIC}] Epic schema validation failed`);
+    if (!summary) logError(`❌ [${ErrorCodes.INVALID_EPIC}] Epic schema validation failed`);
+    if (!summary) logError('💡 Tip: Use --dry-run to preview changes without applying.');
     error = { message: 'Epic schema validation failed', code: ErrorCodes.INVALID_EPIC };
     await recordFailure(error);
     process.exitCode = 1;
@@ -122,7 +125,7 @@ export async function validateEpic(epicFilePath: string, options: ValidateOption
   if (options.council) {
     const verdict = await multiAgentReview(epic);
     if (verdict === CouncilVerdict.REJECTED) {
-      if (!summary) logError(`[${ErrorCodes.VALIDATION_REJECTED}] Council rejected this epic.`);
+      if (!summary) logError(`❌ [${ErrorCodes.VALIDATION_REJECTED}] Council rejected this epic.`);
       error = { message: 'Council rejected this epic.', code: ErrorCodes.VALIDATION_REJECTED };
       await recordFailure(error);
       process.exitCode = 1;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -47,7 +47,7 @@ export function logCooldownWarning(): void {
   if (json) return;
   console.log(
     chalk.red(
-      '🧯 RunSafe is in cooldown mode.\nHigh resource usage or repeated failures detected.\nUse runsafe doctor to troubleshoot, or wait and try again.'
+      '🧊 Cooldown Active\nYou\u2019ve hit a safety cooldown. Wait a few seconds and try again.'
     )
   );
 }


### PR DESCRIPTION
## Summary
- update cooldown warning wording
- prefix errors with ❌ and add validation tips
- verify logging changes in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864de7bec20832cbe3c0bdbec5317f6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * All error log messages now include a red cross emoji (❌) prefix for clearer error indication.
  * Cooldown warning messages have been updated to a shorter, more direct format.

* **Documentation**
  * Error logs for certain validation failures now include a tip about using --dry-run to preview changes.

* **Tests**
  * Enhanced tests to verify the presence of emoji prefixes in error and cooldown warning messages.
  * Added and improved test coverage for error and cooldown warning log outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->