### PR TITLE
Add exit codes and improved tips

### DIFF
--- a/__tests__/apply.test.ts
+++ b/__tests__/apply.test.ts
@@ -68,6 +68,9 @@ beforeEach(() => {
   readFileMock.mockReset();
   writeFileMock.mockReset();
   parseEpicMock.mockReset();
+  // mock process.exit so tests don't exit
+  // @ts-ignore
+  process.exit = jest.fn();
 });
 
 function epicObj(edits: any[] = []) {
@@ -92,6 +95,7 @@ test('gracefully handles invalid epic', async () => {
     code: ErrorCodes.INVALID_EPIC,
   });
   expect(writeFileMock).not.toHaveBeenCalled();
+  expect(process.exit).toHaveBeenCalledWith(1);
 });
 
 /** Test 2 */
@@ -106,6 +110,14 @@ test('logs error if readFile throws', async () => {
     message: 'read fail',
     code: ErrorCodes.FILE_READ_FAIL,
   });
+  expect(process.exit).toHaveBeenCalledWith(1);
+});
+
+/** New Test */
+test('does not exit on dry-run failures', async () => {
+  readFileMock.mockRejectedValueOnce(new Error('fail'));
+  await expect(applyEpic('e.md', { dryRun: true })).resolves.toBeUndefined();
+  expect(process.exit).not.toHaveBeenCalled();
 });
 
 /** Test 3 */

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -141,6 +141,7 @@ export async function applyEpic(file: string, options: ApplyOptions): Promise<vo
     success = false;
     if (summary) logSummary({ success, files: [], error: error.message });
     if (json) emitJson();
+    if (!options.dryRun) process.exit(1);
     return;
   }
 
@@ -163,6 +164,7 @@ export async function applyEpic(file: string, options: ApplyOptions): Promise<vo
     success = false;
     if (summary) logSummary({ success, files: [], error: error.message });
     if (json) emitJson();
+    if (!options.dryRun) process.exit(1);
     return;
   }
 

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -76,14 +76,14 @@ export async function validateEpic(epicFilePath: string, options: ValidateOption
     raw = await fs.readFile(absPath, 'utf8');
   } catch (err) {
     if (!summary) logError(`❌ [${ErrorCodes.FILE_READ_FAIL}] Epic file not found`);
-    if (!summary) logError('💡 Tip: Use --dry-run to preview changes without applying.');
+    if (!summary) logError('💡 Tip: Check the file path and ensure the epic file exists.');
     error = { message: 'Epic file not found', code: ErrorCodes.FILE_READ_FAIL };
     await recordFailure(error);
-    process.exitCode = 1;
     await runtimeLog('validateEpic', { epicFilePath, options }, cooldownReason, error.message, error.code);
     success = false;
     if (summary) logSummary({ success, files: [], error: error.message });
     if (json) emitJson();
+    process.exit(1);
     return;
   }
 
@@ -93,27 +93,27 @@ export async function validateEpic(epicFilePath: string, options: ValidateOption
     summaryText = typeof epic.summary === 'string' ? epic.summary : '';
   } catch (err) {
     if (!summary) logError(`❌ [${ErrorCodes.INVALID_EPIC}] Invalid JSON format`);
-    if (!summary) logError('💡 Tip: Use --dry-run to preview changes without applying.');
+    if (!summary) logError('💡 Tip: Check the JSON syntax and ensure the file is properly formatted.');
     error = { message: 'Invalid JSON format', code: ErrorCodes.INVALID_EPIC };
     await recordFailure(error);
-    process.exitCode = 1;
     await runtimeLog('validateEpic', { epicFilePath, options }, cooldownReason, error.message, error.code);
     success = false;
     if (summary) logSummary({ success, files: [], error: error.message });
     if (json) emitJson();
+    process.exit(1);
     return;
   }
 
   const result = validateSchema(epic);
   if (!result.valid) {
     if (!summary) logError(`❌ [${ErrorCodes.INVALID_EPIC}] Epic schema validation failed`);
-    if (!summary) logError('💡 Tip: Use --dry-run to preview changes without applying.');
+    if (!summary) logError('💡 Tip: Check the epic structure against the required schema.');
     error = { message: 'Epic schema validation failed', code: ErrorCodes.INVALID_EPIC };
     await recordFailure(error);
-    process.exitCode = 1;
     success = false;
     if (summary) logSummary({ success, files: [], error: error.message });
     if (json) emitJson();
+    process.exit(1);
     return;
   }
 


### PR DESCRIPTION
## Summary
- improve validate tips for common error scenarios
- exit with code 1 on validation and apply failures
- update unit tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864e403919c832ca7afe05f2174a148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to ensure the process exits immediately on critical failures, unless running in dry-run mode.
  * Updated error messages to provide more specific guidance for file path, JSON syntax, and schema structure issues.

* **Tests**
  * Enhanced tests to verify process termination behavior and updated assertions to check for explicit process exit calls.
  * Added tests to confirm that process termination does not occur in dry-run scenarios with failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->