### PR TITLE
Remove deprecated ts-jest globals config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,12 +2,15 @@ export default {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   extensionsToTreatAsEsm: ['.ts'],
-  globals: {
-    'ts-jest': {
-      useESM: true,
-      tsconfig: { esModuleInterop: true },
-      diagnostics: false,
-    },
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: { esModuleInterop: true },
+        diagnostics: false,
+      },
+    ],
   },
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',


### PR DESCRIPTION
## Summary
- configure ts-jest using `transform` instead of `globals`

## Testing
- `npx jest --config jest.config.js`

------
https://chatgpt.com/codex/tasks/task_e_6864f04cc62c832c98066f3a31822fe4