### PR TITLE
Cleanup CLI dev loop

### DIFF
--- a/__tests__/apply.test.ts
+++ b/__tests__/apply.test.ts
@@ -1,12 +1,12 @@
 import { jest } from '@jest/globals';
 import * as fs from 'fs';
 import { promises as fsPromises } from 'fs';
-import { parseEpic } from '../src/utils/parseEpic.js';
-import * as logger from '../src/utils/logger.js';
-import { applyEpic } from '../src/commands/apply.js';
-import * as telemetry from '../src/utils/telemetry.js';
-import { isInCooldown } from '../src/utils/cooldown.js';
-import { ErrorCodes } from '../src/constants/errorCodes.js';
+import { parseEpic } from '../src/utils/parseEpic.ts';
+import * as logger from '../src/utils/logger.ts';
+import { applyEpic } from '../src/commands/apply.ts';
+import * as telemetry from '../src/utils/telemetry.ts';
+import { isInCooldown } from '../src/utils/cooldown.ts';
+import { ErrorCodes } from '../src/constants/errorCodes.ts';
 
 jest.mock('chalk', () => ({
   __esModule: true,
@@ -23,12 +23,12 @@ jest.mock('fs', () => ({
   },
 }));
 
-jest.mock('../src/utils/parseEpic.js', () => ({
+jest.mock('../src/utils/parseEpic.ts', () => ({
   parseEpic: jest.fn(),
 }));
 
-jest.mock('../src/utils/logger.js', () => {
-  const actual = jest.requireActual('../src/utils/logger.js');
+jest.mock('../src/utils/logger.ts', () => {
+  const actual = jest.requireActual('../src/utils/logger.ts');
   return {
     ...actual,
     logInfo: jest.fn(),
@@ -41,18 +41,18 @@ jest.mock('../src/utils/logger.js', () => {
   };
 });
 
-jest.mock('../src/utils/telemetry.js', () => ({
+jest.mock('../src/utils/telemetry.ts', () => ({
   recordSuccess: jest.fn(),
   recordFailure: jest.fn(),
   getCooldownReason: jest.fn().mockResolvedValue(null),
   logTelemetry: jest.fn(),
 }));
 
-jest.mock('../src/utils/cooldown.js', () => ({
+jest.mock('../src/utils/cooldown.ts', () => ({
   isInCooldown: jest.fn().mockResolvedValue(false),
 }));
 
-jest.mock('../src/utils/pasteLog.js', () => ({
+jest.mock('../src/utils/pasteLog.ts', () => ({
   writePasteLog: jest.fn(),
 }));
 

--- a/__tests__/logger.test.ts
+++ b/__tests__/logger.test.ts
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { logSummary } from '../src/utils/logger.js';
+import { logSummary } from '../src/utils/logger.ts';
 
 jest.mock('chalk', () => ({
   __esModule: true,

--- a/__tests__/multiAgentReview.test.ts
+++ b/__tests__/multiAgentReview.test.ts
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals';
-import { multiAgentReview } from '../src/ai/multiAgentReview.js';
-import * as agentModule from '../src/ai/agentReview.js';
+import { multiAgentReview } from '../src/ai/multiAgentReview.ts';
+import * as agentModule from '../src/ai/agentReview.ts';
 
 describe('multiAgentReview', () => {
   afterEach(() => {

--- a/__tests__/printUnifiedDiff.test.ts
+++ b/__tests__/printUnifiedDiff.test.ts
@@ -1,7 +1,7 @@
 let printUnifiedDiff: (before: string, after: string, filePath: string) => void;
 
 beforeAll(async () => {
-  ({ printUnifiedDiff } = await import('../src/utils/printUnifiedDiff.js'));
+  ({ printUnifiedDiff } = await import('../src/utils/printUnifiedDiff.ts'));
 });
 
 let logSpy: jest.SpyInstance;

--- a/__tests__/runtimeLog.test.ts
+++ b/__tests__/runtimeLog.test.ts
@@ -1,8 +1,8 @@
 import { jest } from '@jest/globals';
 import path from 'path';
 import { promises as fs } from 'fs';
-import { runtimeLog } from '../src/utils/runtimeLog.js';
-import { getUadoDir } from '../src/utils/getUadoDir.js';
+import { runtimeLog } from '../src/utils/runtimeLog.ts';
+import { getUadoDir } from '../src/utils/getUadoDir.ts';
 
 jest.mock('fs', () => ({
   promises: {

--- a/__tests__/telemetry.test.ts
+++ b/__tests__/telemetry.test.ts
@@ -1,8 +1,8 @@
 import { jest } from '@jest/globals';
 import path from 'path';
 import { promises as fs } from 'fs';
-import { logTelemetry } from '../src/utils/telemetry.js';
-import { getUadoDir } from '../src/utils/getUadoDir.js';
+import { logTelemetry } from '../src/utils/telemetry.ts';
+import { getUadoDir } from '../src/utils/getUadoDir.ts';
 
 jest.mock('chalk', () => ({
   __esModule: true,

--- a/__tests__/validate.test.ts
+++ b/__tests__/validate.test.ts
@@ -6,13 +6,13 @@ import { logInfo, logError, logSuccessFinal, logCooldownWarning } from '../src/u
 import { multiAgentReview, CouncilVerdict } from '../src/utils/multiAgentReview';
 import { validateSchema } from '../src/utils/validateSchema';
 import { recordSuccess, recordFailure, getCooldownReason } from '../src/utils/telemetry';
-import { ErrorCodes } from '../src/constants/errorCodes.js';
+import { ErrorCodes } from '../src/constants/errorCodes.ts';
 
 jest.mock('chalk', () => ({__esModule: true, default: {red:(s:any)=>s, green:(s:any)=>s, cyan:(s:any)=>s, yellow:(s:any)=>s, blue:(s:any)=>s, magenta:(s:any)=>s}}));
 
 jest.mock('fs', () => ({ promises: { readFile: jest.fn(), appendFile: jest.fn(), mkdir: jest.fn() } }));
 jest.mock('../src/utils/logger', () => {
-  const actual = jest.requireActual('../src/utils/logger.js');
+  const actual = jest.requireActual('../src/utils/logger.ts');
   return {
     ...actual,
     logInfo: jest.fn(),
@@ -73,7 +73,7 @@ describe('validateEpic', () => {
 
   it('Cooldown active: should abort and print cooldown warning', async () => {
     ((isInCooldown as any)).mockResolvedValueOnce(true);
-    const real = jest.requireActual('../src/utils/logger.js');
+    const real = jest.requireActual('../src/utils/logger.ts');
     (logCooldownWarning as jest.Mock).mockImplementation(real.logCooldownWarning);
     const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
     await validateEpic('epic.json', {});

--- a/bin/runsafe
+++ b/bin/runsafe
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-import '../src/cli.ts';
+import '../src/index.ts';

--- a/package.json
+++ b/package.json
@@ -6,16 +6,19 @@
     "runsafe": "./bin/runsafe"
   },
   "dependencies": {
-    "commander": "^11.0.0",
     "chalk": "^5.3.0",
+    "commander": "^11.0.0",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.0",
     "jest": "^29.6.0",
     "ts-jest": "^29.1.0",
-    "@types/jest": "^29.5.0"
+    "ts-node": "^10.9.1"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "dev": "ts-node-esm src/index.ts",
+    "build": "tsc"
   }
 }

--- a/src/ai/multiAgentReview.ts
+++ b/src/ai/multiAgentReview.ts
@@ -1,4 +1,4 @@
-import { callAgentReview } from './agentReview.js';
+import { callAgentReview } from './agentReview.ts';
 
 export interface MultiAgentResult {
   decision: 'APPROVED' | 'REJECTED';

--- a/src/commands/apply.js
+++ b/src/commands/apply.js
@@ -1,1 +1,0 @@
-module.exports = require('./apply.ts');

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -13,14 +13,14 @@ import {
   setQuiet,
   logJson,
   setJson,
-} from '../utils/logger.js';
-import { parseEpic, FileEdit } from '../utils/parseEpic.js';
-import { printUnifiedDiff } from "../utils/printUnifiedDiff.js";
-import { writePasteLog } from '../utils/pasteLog.js';
-import { isInCooldown } from '../utils/cooldown.js';
-import { recordSuccess, recordFailure, getCooldownReason, logTelemetry } from '../utils/telemetry.js';
-import { runtimeLog } from '../utils/runtimeLog.js';
-import { ErrorCodes, ErrorCode } from '../constants/errorCodes.js';
+} from '../utils/logger.ts';
+import { parseEpic, FileEdit } from '../utils/parseEpic.ts';
+import { printUnifiedDiff } from "../utils/printUnifiedDiff.ts";
+import { writePasteLog } from '../utils/pasteLog.ts';
+import { isInCooldown } from '../utils/cooldown.ts';
+import { recordSuccess, recordFailure, getCooldownReason, logTelemetry } from '../utils/telemetry.ts';
+import { runtimeLog } from '../utils/runtimeLog.ts';
+import { ErrorCodes, ErrorCode } from '../constants/errorCodes.ts';
 
 interface ApplyOptions {
   dryRun?: boolean;

--- a/src/commands/chains.ts
+++ b/src/commands/chains.ts
@@ -2,8 +2,8 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { load as loadYaml } from 'js-yaml';
-import { logBanner, logError, logWarn, logSuccessFinal } from '../utils/logger.js';
-import { applyEpic } from './apply.js';
+import { logBanner, logError, logWarn, logSuccessFinal } from '../utils/logger.ts';
+import { applyEpic } from './apply.ts';
 
 interface ChainItem {
   file: string;

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,5 +1,5 @@
-import { logInfo } from '../utils/logger.js';
-import { getRecentRuns, RuntimeLogEntry } from '../utils/runtimeLog.js';
+import { logInfo } from '../utils/logger.ts';
+import { getRecentRuns, RuntimeLogEntry } from '../utils/runtimeLog.ts';
 
 function formatDate(iso: string): string {
   return iso.split('T')[0];

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -1,5 +1,5 @@
-import { logInfo } from '../utils/logger.js';
-import { readPasteLog, PasteLogEntry } from '../utils/pasteLog.js';
+import { logInfo } from '../utils/logger.ts';
+import { readPasteLog, PasteLogEntry } from '../utils/pasteLog.ts';
 
 interface HistoryOptions {
   all?: boolean;

--- a/src/commands/replay.ts
+++ b/src/commands/replay.ts
@@ -1,4 +1,4 @@
-import { logInfo } from '../utils/logger.js';
+import { logInfo } from '../utils/logger.ts';
 
 export async function replayPaste(_index: number): Promise<void> {
   logInfo('Replay not implemented yet.');

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -9,13 +9,13 @@ import {
   setQuiet,
   logJson,
   setJson,
-} from '../utils/logger.js';
-import { recordFailure, recordSuccess, getCooldownReason, logTelemetry } from '../utils/telemetry.js';
-import { runtimeLog } from '../utils/runtimeLog.js';
-import { ErrorCodes, ErrorCode } from '../constants/errorCodes.js';
-import { isInCooldown } from '../utils/cooldown.js';
-import { validateSchema } from '../utils/validateSchema.js';
-import { multiAgentReview, CouncilVerdict } from '../utils/multiAgentReview.js';
+} from '../utils/logger.ts';
+import { recordFailure, recordSuccess, getCooldownReason, logTelemetry } from '../utils/telemetry.ts';
+import { runtimeLog } from '../utils/runtimeLog.ts';
+import { ErrorCodes, ErrorCode } from '../constants/errorCodes.ts';
+import { isInCooldown } from '../utils/cooldown.ts';
+import { validateSchema } from '../utils/validateSchema.ts';
+import { multiAgentReview, CouncilVerdict } from '../utils/multiAgentReview.ts';
 
 interface ValidateOptions {
   council?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,20 @@
 // Main CLI definition using commander
 
 import { Command } from 'commander';
-import { loadConfig } from './utils/config.js';
+import { loadConfig } from './utils/config.ts';
 import {
   logInfo,
   logError,
   logBanner,
   logWelcome,
   setQuiet,
-} from './utils/logger.js';
-import { applyEpic } from './commands/apply.js';
-import { validateEpic } from './commands/validate.js';
-import { runDoctor } from './commands/doctor.js';
-import { showHistory } from './commands/history.js';
-import { replayPaste } from './commands/replay.js';
-import { checkFirstRun } from './utils/firstRun.js';
+} from './utils/logger.ts';
+import { applyEpic } from './commands/apply.ts';
+import { validateEpic } from './commands/validate.ts';
+import { runDoctor } from './commands/doctor.ts';
+import { showHistory } from './commands/history.ts';
+import { replayPaste } from './commands/replay.ts';
+import { checkFirstRun } from './utils/firstRun.ts';
 import { createRequire } from 'module';
 
 function showBanner() {
@@ -119,7 +119,7 @@ export async function run(argv: string[]): Promise<void> {
     .command('chains')
     .description('Execute a chain of epics')
     .action(async () => {
-      const { runChains } = await import('./commands/chains.js');
+      const { runChains } = await import('./commands/chains.ts');
       await runChains();
     });
 

--- a/src/utils/cooldown.js
+++ b/src/utils/cooldown.js
@@ -1,1 +1,0 @@
-module.exports = require('./cooldown.ts');

--- a/src/utils/cooldown.ts
+++ b/src/utils/cooldown.ts
@@ -1,4 +1,4 @@
-import { getTelemetry, resetCooldown } from './telemetry.js';
+import { getTelemetry, resetCooldown } from './telemetry.ts';
 
 const IDLE_LIMIT = 10 * 60 * 1000; // 10 minutes
 
@@ -13,4 +13,4 @@ export async function isInCooldown(): Promise<boolean> {
   return true;
 }
 
-export { resetCooldown } from './telemetry.js';
+export { resetCooldown } from './telemetry.ts';

--- a/src/utils/getUadoDir.js
+++ b/src/utils/getUadoDir.js
@@ -1,1 +1,0 @@
-export { getUadoDir } from './getUadoDir.ts';

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,1 +1,0 @@
-module.exports = require('./logger.ts');

--- a/src/utils/parseEpic.js
+++ b/src/utils/parseEpic.js
@@ -1,1 +1,0 @@
-module.exports = require('./parseEpic.ts');

--- a/src/utils/pasteLog.js
+++ b/src/utils/pasteLog.js
@@ -1,1 +1,0 @@
-module.exports = require('./pasteLog.ts');

--- a/src/utils/pasteLog.ts
+++ b/src/utils/pasteLog.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { logWarn, logError, logSuccess } from './logger.js';
+import { logWarn, logError, logSuccess } from './logger.ts';
 
 export interface PasteLogEntry {
   timestamp: string;

--- a/src/utils/printUnifiedDiff.js
+++ b/src/utils/printUnifiedDiff.js
@@ -1,1 +1,0 @@
-module.exports = require('./printUnifiedDiff.ts');

--- a/src/utils/runtimeLog.js
+++ b/src/utils/runtimeLog.js
@@ -1,1 +1,0 @@
-export { runtimeLog } from './runtimeLog.ts';

--- a/src/utils/runtimeLog.ts
+++ b/src/utils/runtimeLog.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { getUadoDir } from './getUadoDir.js';
+import { getUadoDir } from './getUadoDir.ts';
 
 export type CommandName = 'applyEpic' | 'validateEpic';
 

--- a/src/utils/telemetry.js
+++ b/src/utils/telemetry.js
@@ -1,1 +1,0 @@
-module.exports = require('./telemetry.ts');

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { getUadoDir } from './getUadoDir.js';
-import { readPasteLog } from './pasteLog.js';
+import { getUadoDir } from './getUadoDir.ts';
+import { readPasteLog } from './pasteLog.ts';
 
 export interface TelemetryState {
   consecutiveFailures: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,13 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ES2020",
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
-    "strict": false,
-    "skipLibCheck": true
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "ts-node": {
+    "esm": true
   }
 }


### PR DESCRIPTION
## Summary
- streamline commander-based CLI via `src/index.ts`
- remove `.js` wrapper files
- update imports to use `.ts` extensions
- add dev script using ts-node
- minimal tsconfig with `noEmit` and ESM loader

## Testing
- `npm test`
- `npm run dev -- --help` *(fails: ts-node-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff8f503c832cbb7057af0a03874d